### PR TITLE
feat(skills): implement GET/POST endpoints with admin protection

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import morgan from 'morgan';
 import testRoutes from './routes/test.routes';
 import authRoutes from './routes/auth.routes';
 import userRoutes from './routes/user.routes';
+import skillRoutes from './routes/skill.routes';
 
 const app = express();
 
@@ -24,5 +25,6 @@ app.use(cors());
 app.use('/test', testRoutes);
 app.use('/auth', authRoutes);
 app.use('/user', userRoutes);
+app.use('/skill', skillRoutes);
 
 export default app;

--- a/src/controllers/skill.controller.ts
+++ b/src/controllers/skill.controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from 'express';
+import { createSkillService, getSkillService } from '../services/skill.service';
+
+export const createSkill = async (req: Request, res: Response) => {
+    try {
+        const { name } = req.body;
+        const skill = await createSkillService(name);
+        res.status(201).json(skill);
+    } catch (error) {
+        res.status(500).json({ error: 'Error create Skill' });
+    }
+};
+
+export const getSkill = async (req: Request, res: Response) => {
+    try {
+        const skill = await getSkillService();
+
+        res.json(skill);
+    } catch (error) {
+        res.status(500).json({ error: 'Error get Skill' });
+    }
+}

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,8 +1,14 @@
 import { Request, Response } from 'express';
 import { getUserByIdService } from '../services/user.service';
+import { AuthRequest } from '../types/authRequest';
 
-export const getMe = async (req: Request, res: Response) => {
-    const userId = (req as any).userId;
+export const getMe = async (req: AuthRequest, res: Response) => {
+    const userId = req.user?.id;
+
+    if (!userId) {
+        res.status(401).json({ message: "Unauthorized: No user ID" });
+        return;
+    }
 
     try {
         const user = await getUserByIdService(userId);

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,6 +1,11 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
+interface JwtPayload {
+    userId: string;
+    userRol: string;
+}
+
 export const authenticateToken = (req: Request, res: Response, next: NextFunction): void => {
     const authHeader = req.headers.authorization;
     const token = authHeader && authHeader.split(' ')[1];
@@ -11,8 +16,12 @@ export const authenticateToken = (req: Request, res: Response, next: NextFunctio
     }
 
     try {
-        const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as { userId: string };
-        (req as any).userId = decoded.userId;
+        const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as JwtPayload;
+        (req as any).user = {
+            id: decoded.userId,
+            userRol: decoded.userRol
+        };
+
         next();
     } catch {
         res.status(403).json({ error: 'Invalid Token' });

--- a/src/middlewares/isAdmin.middleware.ts
+++ b/src/middlewares/isAdmin.middleware.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+
+interface AuthRequest extends Request {
+    user?: {
+        userRol: string;
+    }
+}
+
+export const isAdmin = (req: AuthRequest, res: Response, next: NextFunction) => {
+    if (req.user?.userRol === 'ADMIN') return next();
+    res.status(403).json({ error: 'Forbidden: Admins only' });
+    return;
+};

--- a/src/routes/skill.routes.ts
+++ b/src/routes/skill.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { createSkill, getSkill } from '../controllers/skill.controller';
+import { authenticateToken } from '../middlewares/auth.middleware';
+import { isAdmin } from '../middlewares/isAdmin.middleware';
+
+const router = Router();
+
+router.post("/", authenticateToken, isAdmin, createSkill);
+router.get("/", getSkill);
+
+export default router;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -14,7 +14,7 @@ export const registerUserService = async (name: string, username: string, email:
         data: { name, username, email, password: hashed },
     });
 
-    const token = generateToken({ userId: user.id });
+    const token = generateToken({ userId: user.id, userRol: user.userRol });
     return { user, token };
 };
 
@@ -25,6 +25,6 @@ export const loginUserService = async (username: string, password: string) => {
     const match = await bcrypt.compare(password, user.password);
     if (!match) throw new Error('Invalid credentials');
 
-    const token = generateToken({ userId: user.id });
+    const token = generateToken({ userId: user.id, userRol: user.userRol });
     return { user, token };
 }

--- a/src/services/skill.service.ts
+++ b/src/services/skill.service.ts
@@ -1,0 +1,11 @@
+import prisma from '../utils/prisma.util';
+
+export const createSkillService = async (name: string) => {
+    return await prisma.skill.create({
+        data: { name }
+    });
+};
+
+export const getSkillService = async () => {
+    return await prisma.skill.findMany();
+};

--- a/src/types/authRequest.d.ts
+++ b/src/types/authRequest.d.ts
@@ -1,0 +1,8 @@
+import { Request } from 'express';
+
+export interface AuthRequest extends Request {
+    user?: {
+        id: string;
+        userRol: string;
+    };
+}


### PR DESCRIPTION
## Changes  
-  `GET /skills`: List all skills  
-  `POST /skills`: Admins only (`isAdmin` middleware)  

## Structure  
````typescript
// POST /skills
{
  “name": ‘TypeScript’ // Required, unique
}
````
#9  