### PR TITLE
feat(rating): Add user rating feature with like/dislike and reputation tracking

### DIFF
--- a/prisma/migrations/20250625005046_add_reputation_fields_to_user/migration.sql
+++ b/prisma/migrations/20250625005046_add_reputation_fields_to_user/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "dislikesReceived" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "likesReceived" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,10 @@ model User {
     twitter         String?
     website         String?
 
+    // Reputación
+    likesReceived    Int      @default(0)
+    dislikesReceived Int      @default(0)
+
     // Log Rating
     ratingsGiven      LogRating[]   @relation("GivenRatings")
     ratingsReceived   LogRating[]   @relation("ReceivedRatings")

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import projectRoutes from './routes/project.route';
 import joinRequestRoutes from './routes/joinRequest.routes';
 import vacancyRoutes from './routes/vacancy.routes';
 import categoryRoutes from './routes/category.routes';
+import logRatingRoutes from './routes/logRating.routes';
 
 const app = express();
 
@@ -36,5 +37,6 @@ app.use('/project', projectRoutes);
 app.use('/join-request', joinRequestRoutes);
 app.use('/vacancy', vacancyRoutes);
 app.use('/category', categoryRoutes);
+app.use('/rating', logRatingRoutes);
 
 export default app;

--- a/src/controllers/logRating.controller.ts
+++ b/src/controllers/logRating.controller.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+import { rateUserService } from '../services/logRating.service';
+
+export const rateUser = async (req: Request, res: Response) => {
+    try {
+        const { toUserId, isLike } = req.body;
+        const fromUserId = req.user?.id; // Asumiendo que usas auth middleware
+
+        if (!fromUserId) {
+            res.status(401).json({ error: 'Unauthorized' });
+            return;
+        }
+        if (!toUserId || typeof isLike !== 'boolean') {
+            res.status(400).json({ error: 'toUserId and isLike are required' });
+            return;
+        }
+
+        const result = await rateUserService({ fromUserId, toUserId, isLike });
+        res.status(201).json(result);
+    } catch (err: any) {
+        res.status(400).json({ error: err.message });
+    }
+};

--- a/src/routes/logRating.routes.ts
+++ b/src/routes/logRating.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { rateUser } from '../controllers/logRating.controller';
+import { authenticateToken } from '../middlewares/auth.middleware';
+
+const router = Router();
+
+router.post('/', authenticateToken, rateUser);
+
+export default router;

--- a/src/services/logRating.service.ts
+++ b/src/services/logRating.service.ts
@@ -1,0 +1,42 @@
+import prisma from "../utils/prisma.util";
+
+export const rateUserService = async ({
+    fromUserId,
+    toUserId,
+    isLike,
+}: {
+    fromUserId: string;
+    toUserId: string;
+    isLike: boolean;
+}) => {
+    if (fromUserId === toUserId) {
+        throw new Error("You can't rate yourself.");
+    }
+
+    // verifica si ya existe un voto previo
+    const existing = await prisma.logRating.findUnique({
+        where: {
+            fromUserId_toUserId: { fromUserId, toUserId },
+        },
+    });
+
+    if (existing) {
+        throw new Error('You already rated this user.');
+    }
+
+    // crea el rating
+    await prisma.logRating.create({
+        data: { fromUserId, toUserId, isLike },
+    });
+
+    // actualiza contador
+    await prisma.user.update({
+        where: { id: toUserId },
+        data: {
+            likesReceived: isLike ? { increment: 1 } : undefined,
+            dislikesReceived: !isLike ? { increment: 1 } : undefined,
+        },
+    });
+
+    return { message: 'Rating submitted successfully' };
+};

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -11,11 +11,13 @@ export const getUserByIdService = async (id: string) => {
             userRol: true,
             avatarUrl: true,
             registeredAt: true,
+            likesReceived: true,
+            dislikesReceived: true,
             userSkills: {
                 select: {
                     skill: true,
                 }
-            }
+            },
         },
     });
 };
@@ -31,6 +33,8 @@ export const getUserByUsernameService = async (username: string) => {
             userRol: true,
             avatarUrl: true,
             registeredAt: true,
+            likesReceived: true,
+            dislikesReceived: true,
             userSkills: {
                 select: {
                     skill: true,


### PR DESCRIPTION
## Summary

- Introduced a new `LogRating` model to track like/dislike ratings between users
- Users can rate each other once (no duplicates)
- Added `likesReceived` and `dislikesReceived` to User model
- Implemented full separation of concerns: service, controller, and route
- Secured with basic auth requirement (expects req.user.id from middleware)

## Endpoint

- `POST /api/ratings`
- Body: { toUserId: string, isLike: boolean }

## Notes

- Validation prevents self-voting and duplicate votes
- Reputation counters are auto-updated

#27 