### PR TITLE
feat(user): implement endpoint to update user profile and social links

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { addUserSkillService, getUserByIdService, getUserByUsernameService, removeUserSkillService } from '../services/user.service';
+import { addUserSkillService, getUserByIdService, getUserByUsernameService, removeUserSkillService, updateUserService } from '../services/user.service';
 import { AuthRequest } from '../types/index'
 
 export const getMe = async (req: AuthRequest, res: Response) => {
@@ -62,5 +62,38 @@ export const removeUserSkill = async (req: AuthRequest, res: Response) => {
         res.status(204).send();
     } catch {
         res.status(500).json({ message: 'Error deleting skill' });
+    }
+};
+
+export const updateUser = async (req: AuthRequest, res: Response) => {
+    const userId = req.user?.id;
+
+    if (!userId) {
+        res.status(401).json({ message: "Unauthorized: No user ID" });
+        return;
+    }
+
+    const allowedField = [
+        'name',
+        'description',
+        'github',
+        'linkedin',
+        'twitter',
+        'website',
+    ];
+
+    const updateData: Record<string, string> = {};
+    for (const field of allowedField) {
+        if (req.body[field] !== undefined) {
+            updateData[field] = req.body[field];
+        }
+    }
+
+    try {
+        const updated = await updateUserService(userId, updateData);
+
+        res.json(updated);
+    } catch (error) {
+        res.status(500).json({ message: "Error to updated user" });
     }
 };

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
-import { addSkillUser, getMe, getUserByUsername, removeUserSkill } from '../controllers/user.controller';
+import { addSkillUser, getMe, getUserByUsername, removeUserSkill, updateUser } from '../controllers/user.controller';
 import { authenticateToken } from '../middlewares/auth.middleware';
 
 const router = Router();
 
 router.get("/me", authenticateToken, getMe);
 router.get("/:username", getUserByUsername);
+router.put("/me", authenticateToken, updateUser);
 
 // userSkills integrated
 router.post("/me/skills", authenticateToken, addSkillUser);

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -117,3 +117,17 @@ export const removeUserSkillService = async (userId: string, skillId: string) =>
         where: { userId_skillId: { userId, skillId } },
     });
 };
+
+export const updateUserService = async (id: string, data: Partial<{
+    name: string;
+    description: string;
+    github: string,
+    linkedin: string;
+    twitter: string;
+    website: string;
+}>) => {
+    return prisma.user.update({
+        where: { id },
+        data,
+    });
+};


### PR DESCRIPTION
## Summary

- Adds `PUT /api/user/me` endpoint to allow users to update their own profile
- Fields allowed: name, description, ~avatarUrl~, github, linkedin, twitter, website
- Only the user can modify the profile

## Example usage

PUT /api/user/me
Body:
{
  "name": "Felipe",
  "github": "felipecastillo-b"
}

#31 