### PR TITLE
feat(project): add endpoint to remove project members and cleanup join request

### DIFF
--- a/src/routes/project.route.ts
+++ b/src/routes/project.route.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createProject, getAllProjects, getProjectById, updatePermission, updateProject } from '../controllers/project.controller';
+import { createProject, getAllProjects, getProjectById, removeProjectMember, updatePermission, updateProject } from '../controllers/project.controller';
 import { authenticateToken } from '../middlewares/auth.middleware';
 
 const router = Router();
@@ -10,5 +10,7 @@ router.get("/:id", getProjectById);
 router.put("/:id", authenticateToken, updateProject);
 
 router.put("/:id/members/:userId/permission", authenticateToken, updatePermission);
+
+router.delete("/:id/members/:userId", authenticateToken, removeProjectMember);
 
 export default router;


### PR DESCRIPTION
## Summary

- Adds DELETE Member endpoint
- Only project ADMIN or MODERATOR can remove other members
- Prevents self-removal
- Cleans up any existing join requests for the removed member

## Notes

- Prevents duplicate JoinRequest on rejoining

#40 