### PR TITLE
feat(project): add endpoint for members and moderators to leave project

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { createProjectService, getAllProjectsService, getProjectByIdService, removeProjectMemberService, updatePermissionService, updateProjectService } from '../services/project.service';
+import { createProjectService, getAllProjectsService, getProjectByIdService, leaveProjectService, removeProjectMemberService, updatePermissionService, updateProjectService } from '../services/project.service';
 import { getUserIdRequest } from '../utils/getUserIdRequest.util';
 
 export const createProject = async (req: Request, res: Response) => {
@@ -115,8 +115,8 @@ export const removeProjectMember = async (req: Request, res: Response) => {
 
     try {
         const removeMember = await removeProjectMemberService(
-            id, 
-            userId, 
+            id,
+            userId,
             requesterId
         );
 
@@ -139,6 +139,30 @@ export const removeProjectMember = async (req: Request, res: Response) => {
                 res.status(404).json({ error: 'Target member not found in this project' });
             }
         }
+
+        console.error(err);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+};
+
+export const leaveProject = async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const userId = getUserIdRequest(req);
+
+    try {
+        await leaveProjectService(id, userId);
+
+        res.json({ message: 'You have left the project successfully' });
+    } catch (err) {
+        if (err instanceof Error) {
+            if (err.message === 'NOT_A_MEMBER') {
+                res.status(400).json({ error: 'You are not a member of this project' });
+            }
+
+            if (err.message === 'ADMIN_CANNOT_LEAVE') {
+                res.status(403).json({ error: 'Project admin cannot leave the project' });
+            }
+        };
 
         console.error(err);
         res.status(500).json({ error: 'Internal server error' });

--- a/src/routes/project.route.ts
+++ b/src/routes/project.route.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createProject, getAllProjects, getProjectById, removeProjectMember, updatePermission, updateProject } from '../controllers/project.controller';
+import { createProject, getAllProjects, getProjectById, leaveProject, removeProjectMember, updatePermission, updateProject } from '../controllers/project.controller';
 import { authenticateToken } from '../middlewares/auth.middleware';
 
 const router = Router();
@@ -12,5 +12,6 @@ router.put("/:id", authenticateToken, updateProject);
 router.put("/:id/members/:userId/permission", authenticateToken, updatePermission);
 
 router.delete("/:id/members/:userId", authenticateToken, removeProjectMember);
+router.delete("/:id/leave", authenticateToken, leaveProject);
 
 export default router;


### PR DESCRIPTION
## Summary

- Adds DELETE leave project endpoint
- Allows users to leave projects if they are not ADMIN
- ADMINs are restricted to prevent orphaned projects
- Cleans up old JoinRequest to avoid duplication later

## Notes

- Works for users with MEMBER or MODERATOR permission only

#42 